### PR TITLE
Replace instances of "Screen."

### DIFF
--- a/depecher/qml/pages/PicturePage.qml
+++ b/depecher/qml/pages/PicturePage.qml
@@ -48,7 +48,7 @@ Page {
                     fillMode: Image.PreserveAspectFit
                     cache: true
                     asynchronous: true
-                    sourceSize.width:  Screen.width;
+                    sourceSize.width:  root.width;
                     smooth: false
 
                     onScaleChanged: {

--- a/depecher/qml/pages/components/settings/AppearancePage.qml
+++ b/depecher/qml/pages/components/settings/AppearancePage.qml
@@ -72,7 +72,7 @@ Page {
             }
             SilicaListView {
                 width: parent.width
-                height: Screen.height/2 + Theme.itemSizeMedium
+                height: root.height/2 + Theme.itemSizeMedium
                 clip:true
                 model:messagingModel
                 header: PageHeader {

--- a/depecher/qml/pages/items/AttachComponent.qml
+++ b/depecher/qml/pages/items/AttachComponent.qml
@@ -148,8 +148,8 @@ Item {
                 asynchronous: true
                 // From org.nemomobile.thumbnailer
                 source:   "image://nemoThumbnail/"+url
-                sourceSize: Qt.size(Screen.width/3,Screen.width/3)
-                width: Screen.width/3
+                sourceSize: Qt.size(thumbnailWrapper.width/3,thumbnailWrapper.width/3)
+                width: thumbnailWrapper.width/3
                 height: width
 
                 Rectangle{

--- a/depecher/qml/pages/items/AttachSticker.qml
+++ b/depecher/qml/pages/items/AttachSticker.qml
@@ -156,7 +156,7 @@ Item {
             width: parent.width
             height: parent.height - thumbnails.height
             property int indexAtTop: 0
-            onContentYChanged: indexAtTop = indexAt(Screen.width/2,contentY + height/2)
+            onContentYChanged: indexAtTop = indexAt(root.width/2,contentY + height/2)
             clip:true
             interactive: !_previewEnabled
             onDragStarted: {

--- a/depecher/qml/pages/items/MessageItem.qml
+++ b/depecher/qml/pages/items/MessageItem.qml
@@ -283,7 +283,7 @@ ListItem {
                 font.pixelSize: Theme.fontSizeSmall
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                 Component.onCompleted: {
-                    width = Math.min(width ,Screen.width * 2 /3 - Theme.horizontalPageMargin * 2)
+                    width = Math.min(width ,messageListItem.width * 2 /3 - Theme.horizontalPageMargin * 2)
                 }
             }
         }
@@ -291,7 +291,7 @@ ListItem {
     Component {
         id: contactContent
         BackgroundItem {
-            property int maxWidth: Screen.width *2/3 - Theme.horizontalPageMargin * 2
+            property int maxWidth: messageListItem.width *2/3 - Theme.horizontalPageMargin * 2
             width: maxWidth
             height: Theme.itemSizeMedium
             DBusInterface {
@@ -338,8 +338,8 @@ ListItem {
             Image {
                 id: image
                 asynchronous: true
-                property int maxWidth: Screen.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                property int maxHeight: Screen.height/2
+                property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
+                property int maxHeight: messageListItem.height/2
                 width: photo_aspect >= 1 ? maxWidth : maxHeight * photo_aspect
                 height: photo_aspect >= 1 ? maxWidth/photo_aspect : maxHeight
                 fillMode: Image.PreserveAspectFit
@@ -398,7 +398,7 @@ ListItem {
         id: documentContent
 
         Column{
-            property int maxWidth: Screen.width *2/3 - Theme.horizontalPageMargin * 2
+            property int maxWidth: messageListItem.width *2/3 - Theme.horizontalPageMargin * 2
             width: maxWidth
 
             BackgroundItem {
@@ -491,7 +491,7 @@ ListItem {
 
         Column {
             width: stickerImage.width//messageListItem.width/4*3
-            property int maxWidth: Screen.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
+            property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
 
             Image {
                 id:stickerImage
@@ -511,7 +511,7 @@ ListItem {
         id: newMessageContent
 
         Item {
-            width: Screen.width
+            width: messageListItem.width
             height: Theme.itemSizeSmall
             x:Theme.horizontalPageMargin/2
 
@@ -539,7 +539,7 @@ ListItem {
         id: joinByLinkContent
 
         Item {
-            width:  Screen.width
+            width:  messageListItem.width
             height: Theme.itemSizeSmall
             x:Theme.horizontalPageMargin/2
             Rectangle {
@@ -567,7 +567,7 @@ ListItem {
         id: joinedContent
 
         Item {
-            width: Screen.width
+            width: messageListItem.width
             height: Theme.itemSizeSmall
             x:Theme.horizontalPageMargin/2
 
@@ -595,7 +595,7 @@ ListItem {
         id: chatCreatedContent
 
         Item {
-            width: Screen.width
+            width: messageListItem.width
             height: Theme.itemSizeSmall
             x:Theme.horizontalPageMargin/2
 
@@ -626,8 +626,8 @@ ListItem {
                 id:gifComponent
                 AnimatedImage {
                     id:animationGif
-                    property int maxWidth: Screen.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                    property int maxHeight: Screen.height/2
+                    property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
+                    property int maxHeight: messageListItem.height/2
                     width: photo_aspect > 1 ? maxWidth : maxHeight * photo_aspect
                     height: photo_aspect > 1 ? maxWidth/photo_aspect : maxHeight
                     fillMode: VideoOutput.PreserveAspectFit
@@ -720,8 +720,8 @@ ListItem {
                 id:mp4Component
                 VideoOutput {
                     id: animation
-                    property int maxWidth: Screen.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                    property int maxHeight: Screen.height/2
+                    property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
+                    property int maxHeight: messageListItem.height/2
                     width: photo_aspect > 1 ? maxWidth : maxHeight * photo_aspect
                     height: photo_aspect > 1 ? maxWidth/photo_aspect : maxHeight
                     fillMode: VideoOutput.PreserveAspectFit

--- a/depecher/qml/pages/items/MessageItem.qml
+++ b/depecher/qml/pages/items/MessageItem.qml
@@ -339,7 +339,7 @@ ListItem {
                 id: image
                 asynchronous: true
                 property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                property int maxHeight: messageListItem.height/2
+                property int maxHeight: page.height/2
                 width: photo_aspect >= 1 ? maxWidth : maxHeight * photo_aspect
                 height: photo_aspect >= 1 ? maxWidth/photo_aspect : maxHeight
                 fillMode: Image.PreserveAspectFit
@@ -627,7 +627,7 @@ ListItem {
                 AnimatedImage {
                     id:animationGif
                     property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                    property int maxHeight: messageListItem.height/2
+                    property int maxHeight: page.height/2
                     width: photo_aspect > 1 ? maxWidth : maxHeight * photo_aspect
                     height: photo_aspect > 1 ? maxWidth/photo_aspect : maxHeight
                     fillMode: VideoOutput.PreserveAspectFit
@@ -721,7 +721,7 @@ ListItem {
                 VideoOutput {
                     id: animation
                     property int maxWidth: messageListItem.width-Theme.itemSizeExtraSmall - Theme.paddingMedium - 2*Theme.horizontalPageMargin
-                    property int maxHeight: messageListItem.height/2
+                    property int maxHeight: page.height/2
                     width: photo_aspect > 1 ? maxWidth : maxHeight * photo_aspect
                     height: photo_aspect > 1 ? maxWidth/photo_aspect : maxHeight
                     fillMode: VideoOutput.PreserveAspectFit


### PR DESCRIPTION
fixes #72 
Okay, this was easier/faster than I thought after you helped me kickstart the build process.

I have not replaced occurences in `qml/pages/items/delegates`, because it wasn't clear to me how they are used. But this should reduce the amount of scrolling needed in landscape for the time being.

Before:
![before](https://i.imgur.com/CjavYgz.png)
After:
![after](https://i.imgur.com/QcWqZSj.png)